### PR TITLE
feat: optimize encode and decode on M3 Mac

### DIFF
--- a/examples/bench_simd.rs
+++ b/examples/bench_simd.rs
@@ -1,0 +1,187 @@
+use binseq::{is_simd_supported, nuc};
+use std::time::{Duration, Instant};
+use rand::Rng;
+
+fn generate_random_sequence(len: usize) -> Vec<u8> {
+    let mut sequence = Vec::with_capacity(len);
+    let nucleotides = [b'A', b'C', b'G', b'T'];
+    let mut rng = rand::thread_rng();
+    
+    for _ in 0..len {
+        let idx = rng.gen_range(0..4);
+        sequence.push(nucleotides[idx]);
+    }
+    
+    sequence
+}
+
+struct BenchmarkResult {
+    sequence_length: usize,
+    iterations: usize,
+    bitnuc_duration: Duration,
+    simd_duration: Duration,
+    bitnuc_speed: f64,
+    simd_speed: f64,
+    speedup: f64,
+}
+
+fn benchmark_encode(sequence: &[u8], iterations: usize) -> BenchmarkResult {
+    // Verify the sequence only contains valid nucleotides
+    for &b in sequence {
+        match b {
+            b'A' | b'C' | b'G' | b'T' => {},
+            other => panic!("Invalid nucleotide in sequence: {}", other),
+        }
+    }
+    let chunks = (sequence.len() + 31) / 32;
+    
+    let mut bitnuc_output = Vec::with_capacity(chunks);
+    bitnuc_output.resize(chunks, 0);
+    
+    let start = Instant::now();
+    for _ in 0..iterations {
+        bitnuc_output.clear();
+        bitnuc_output.resize(chunks, 0);
+        bitnuc::encode(sequence, &mut bitnuc_output).unwrap();
+    }
+    let bitnuc_duration = start.elapsed();
+    
+    let mut simd_output = vec![0u64; chunks];
+    let start = Instant::now();
+    for _ in 0..iterations {
+        simd_output.clear();
+        simd_output.resize(chunks, 0);
+        nuc::encode(sequence, &mut simd_output).unwrap();
+    }
+    let simd_duration = start.elapsed();
+    
+    // Calculate processing speeds in millions of nucleotides per second
+    let bitnuc_speed = (sequence.len() * iterations) as f64 / bitnuc_duration.as_secs_f64() / 1_000_000.0;
+    let simd_speed = (sequence.len() * iterations) as f64 / simd_duration.as_secs_f64() / 1_000_000.0;
+    let speedup = bitnuc_duration.as_secs_f64() / simd_duration.as_secs_f64();
+    
+    BenchmarkResult {
+        sequence_length: sequence.len(),
+        iterations,
+        bitnuc_duration,
+        simd_duration,
+        bitnuc_speed,
+        simd_speed,
+        speedup,
+    }
+}
+
+fn benchmark_decode(sequence: &[u8], iterations: usize) -> BenchmarkResult {
+    // Verify the sequence only contains valid nucleotides
+    for &b in sequence {
+        match b {
+            b'A' | b'C' | b'G' | b'T' => {},
+            other => panic!("Invalid nucleotide in sequence: {}", other),
+        }
+    }
+    let chunks = (sequence.len() + 31) / 32;
+    let mut encoded = vec![0u64; chunks];
+    bitnuc::encode(sequence, &mut encoded).unwrap();
+    
+    let mut decoded = Vec::new();
+    let start = Instant::now();
+    for _ in 0..iterations {
+        decoded.clear();
+        bitnuc::decode(&encoded, sequence.len(), &mut decoded).unwrap();
+    }
+    let bitnuc_duration = start.elapsed();
+    
+    let mut decoded = Vec::new();
+    let start = Instant::now();
+    for _ in 0..iterations {
+        decoded.clear();
+        nuc::decode(&encoded, sequence.len(), &mut decoded).unwrap();
+    }
+    let simd_duration = start.elapsed();
+    
+    // Calculate processing speeds in millions of nucleotides per second
+    let bitnuc_speed = (sequence.len() * iterations) as f64 / bitnuc_duration.as_secs_f64() / 1_000_000.0;
+    let simd_speed = (sequence.len() * iterations) as f64 / simd_duration.as_secs_f64() / 1_000_000.0;
+    let speedup = bitnuc_duration.as_secs_f64() / simd_duration.as_secs_f64();
+    
+    BenchmarkResult {
+        sequence_length: sequence.len(),
+        iterations,
+        bitnuc_duration,
+        simd_duration,
+        bitnuc_speed,
+        simd_speed,
+        speedup,
+    }
+}
+
+fn print_table_header(operation: &str) {
+    println!("\n{} Benchmark Results", operation);
+    println!("{:-<106}", "");
+    println!("| {:<10} | {:<10} | {:<15} | {:<15} | {:<12} | {:<12} | {:<8} |", 
+        "Length", "Iterations", "Original (ms)", "SIMD (ms)", "Orig (Mnuc/s)", "SIMD (Mnuc/s)", "Speedup");
+    println!("{:-<106}", "");
+}
+
+fn print_table_row(result: &BenchmarkResult) {
+    println!("| {:<10} | {:<10} | {:<15} | {:<15} | {:<13.2} | {:<13.2} | {:<8.2} |",
+        result.sequence_length,
+        result.iterations,
+        result.bitnuc_duration.as_millis(),
+        result.simd_duration.as_millis(),
+        result.bitnuc_speed,
+        result.simd_speed,
+        result.speedup);
+}
+
+fn print_table_footer() {
+    println!("{:-<106}", "");
+}
+
+fn main() {
+    // Print architecture information (ARM only)
+    println!("Architecture: aarch64 (ARM64)");
+    println!("SIMD support detected: {}", is_simd_supported());
+    
+    // Test with different sequence lengths
+    let sequence_lengths = [
+        32,      // Exactly one SIMD vector on x86_64 or 2 vectors on aarch64
+        64,      // Two SIMD vectors on x86_64 or 4 vectors on aarch64
+        100,     // Not a multiple of vector size
+        1000,    // Longer sequence
+        10000,   // Much longer sequence
+        100000,  // Very long sequence
+        1000000, // Extremely long sequence
+        5000000, // Extremely Extremely long sequence
+    ];
+    
+    let iterations = 1000;
+    
+    // Collect encode benchmark results
+    let mut encode_results = Vec::new();
+    for &len in &sequence_lengths {
+        let sequence = generate_random_sequence(len);
+        encode_results.push(benchmark_encode(&sequence, iterations));
+    }
+    
+    // Collect decode benchmark results
+    let mut decode_results = Vec::new();
+    for &len in &sequence_lengths {
+        let sequence = generate_random_sequence(len);
+        decode_results.push(benchmark_decode(&sequence, iterations));
+    }
+    
+    // Print encode results table
+    print_table_header("Encode");
+    for result in &encode_results {
+        print_table_row(result);
+    }
+    print_table_footer();
+    
+    // Print decode results table
+    print_table_header("Decode");
+    for result in &decode_results {
+        print_table_row(result);
+    }
+    print_table_footer();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! - Parallel processing capabilities
 //! - Configurable policies for handling invalid nucleotides
 //! - Support for both single and paired-end sequences
+//! - SIMD acceleration for faster encoding/decoding (on supported CPUs)
 //!
 //! # Core Components
 //!
@@ -45,9 +46,11 @@
 
 pub mod error;
 mod header;
+pub mod nuc;
 mod parallel;
 mod policy;
 mod reader;
+mod simd;
 mod utils;
 pub mod writer;
 
@@ -56,6 +59,7 @@ pub use header::{BinseqHeader, SIZE_HEADER};
 pub use parallel::ParallelProcessor;
 pub use policy::{Policy, RNG_SEED};
 pub use reader::{MmapReader, RefRecord};
+pub use simd::is_simd_supported;
 pub use utils::expected_file_size;
 pub use writer::{BinseqWriter, BinseqWriterBuilder, Encoder};
 

--- a/src/nuc.rs
+++ b/src/nuc.rs
@@ -1,0 +1,138 @@
+//! Nucleotide encoding and decoding module with SIMD acceleration
+//!
+//! This module provides accelerated functions for encoding and decoding nucleotides
+//! using SIMD instructions when available. It wraps the underlying `bitnuc` crate
+//! and transparently uses SIMD operations on compatible hardware, falling back to
+//! scalar operations when necessary.
+
+use crate::error::Error;
+use crate::simd::is_simd_supported;
+use crate::Result;
+
+/// Encodes nucleotides to 2-bit representation with potential SIMD acceleration
+///
+/// This function is a direct replacement for `bitnuc::encode`, but it will use
+/// SIMD instructions when available for better performance.
+///
+/// # Arguments
+///
+/// * `input` - A slice of ASCII nucleotides (A, C, G, T)
+/// * `output` - A mutable slice to store the encoded nucleotides
+///
+/// # Returns
+///
+/// * `Ok(())` - If encoding was successful
+/// * `Err(Error)` - If invalid nucleotides were found in the input
+///
+/// # Example
+///
+/// ```
+/// use binseq::nuc;
+///
+/// let sequence = b"ACGTACGT";
+/// let mut output = vec![0u64; 2]; // Allocate enough space for the encoded sequence
+/// nuc::encode(sequence, &mut output).unwrap();
+/// ```
+pub fn encode(input: &[u8], output: &mut Vec<u64>) -> Result<()> {
+    if input.len() > 1_000
+        && is_simd_supported()
+        && crate::simd::aarch64::encode(input, output).is_ok()
+    {
+        return Ok(());
+    }
+
+    // Use scalar implementation
+    bitnuc::encode(input, output).map_err(Error::from)
+}
+
+/// Decodes 2-bit nucleotides to ASCII with potential SIMD acceleration
+///
+/// This function is a direct replacement for `bitnuc::decode`, but it will use
+/// SIMD instructions when available for better performance.
+///
+/// # Arguments
+///
+/// * `input` - A slice of encoded 2-bit nucleotides
+/// * `len` - The number of nucleotides to decode
+/// * `output` - A mutable vector to store the decoded ASCII nucleotides
+///
+/// # Returns
+///
+/// * `Ok(())` - If decoding was successful
+/// * `Err(Error)` - If an error occurred during decoding
+///
+/// # Example
+///
+/// ```
+/// use binseq::nuc;
+///
+/// let encoded = [0xe4]; // Encoded "ACGT" (binary: 11 10 01 00)
+/// let mut output = Vec::new();
+/// nuc::decode(&encoded, 4, &mut output).unwrap();
+/// assert_eq!(output, b"ACGT");
+/// ```
+pub fn decode(input: &[u64], len: usize, output: &mut Vec<u8>) -> Result<()> {
+    if input.len() > 1_000
+        && is_simd_supported()
+        && crate::simd::aarch64::decode(input, len, output).is_ok()
+    {
+        return Ok(());
+    }
+
+    bitnuc::decode(input, len, output).map_err(Error::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+
+    use super::*;
+
+    #[test]
+    fn test_encode_decode_simple() {
+        let sequence = b"ACGTACGT";
+        let mut encoded = vec![0u64; 2]; // Allocate enough space for the encoded sequence
+        let mut decoded = Vec::new();
+        encode(sequence, &mut encoded).unwrap();
+        decode(&encoded, sequence.len(), &mut decoded).unwrap();
+        assert_eq!(sequence, decoded.as_slice());
+    }
+
+    #[test]
+    fn test_encode_invalid() {
+        let sequence = b"ACGTNACGT"; // Contains 'N'
+        let encoded = [0u64; 1];
+        let mut vec_encoded = vec![0; encoded.len()];
+        vec_encoded.resize(encoded.len(), 0);
+        let result = bitnuc::encode(sequence, &mut vec_encoded);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid nucleotide base: 78"
+        );
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn test_longer_sequence() {
+        let sequence = b"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+        let mut encoded = [0u64; 2];
+        unsafe {
+            crate::simd::aarch64::encode_nucleotides_simd(sequence, &mut encoded).unwrap();
+        }
+        let mut decoded = Vec::new();
+        decode(&encoded, sequence.len(), &mut decoded).unwrap();
+        assert_eq!(sequence, decoded.as_slice());
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn test_differnt() {
+        let sequence = b"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+        let mut encoded = Vec::new();
+        let mut decoded = Vec::new();
+        crate::simd::aarch64::encode(sequence, &mut encoded).unwrap();
+        decode(&encoded, sequence.len(), &mut decoded).unwrap();
+        assert_eq!(sequence, decoded.as_slice());
+    }
+}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -91,7 +91,7 @@ impl<'a> RefRecord<'a> {
     ///
     /// Returns an error if the decoding process fails
     pub fn decode_s(&self, dbuf: &mut Vec<u8>) -> Result<()> {
-        bitnuc::decode(self.sbuf(), self.config.slen, dbuf)?;
+        crate::nuc::decode(self.sbuf(), self.config.slen, dbuf)?;
         Ok(())
     }
 
@@ -108,7 +108,7 @@ impl<'a> RefRecord<'a> {
     ///
     /// Returns an error if the decoding process fails
     pub fn decode_x(&self, dbuf: &mut Vec<u8>) -> Result<()> {
-        bitnuc::decode(self.xbuf(), self.config.xlen, dbuf)?;
+        crate::nuc::decode(self.xbuf(), self.config.xlen, dbuf)?;
         Ok(())
     }
     /// Returns whether this record contains extended sequence data

--- a/src/simd/aarch64.rs
+++ b/src/simd/aarch64.rs
@@ -1,0 +1,200 @@
+use std::arch::aarch64::*;
+
+/// **AArch64 NEON availability** – always `true` on ARM64.
+#[inline]
+pub fn is_neon_supported() -> bool {
+    true
+}
+
+/// Encode 16 ASCII nucleotides (`A`, `C`, `G`, `T`) into a single `u32`.
+///
+/// Output layout: nt0 → bits 0‑1 … nt15 → bits 30‑31 (little‑endian).
+#[inline(always)]
+pub unsafe fn encode_16_nucleotides(nucs: uint8x16_t) -> u32 {
+    // 1. ASCII → 2‑bit codes: code = ((b >> 1) ^ (b >> 2)) & 3
+    let t1 = vshrq_n_u8(nucs, 1);
+    let t2 = vshrq_n_u8(nucs, 2);
+    let code = vandq_u8(veorq_u8(t1, t2), vdupq_n_u8(3));
+
+    // 2. Pack two codes into one 4‑bit nibble
+    let even = vuzp1q_u8(code, code); // c0, c2, …, c14
+    let odd = vuzp2q_u8(code, code); // c1, c3, …, c15
+    let nibbles = vorrq_u8(even, vshlq_n_u8(odd, 2));
+
+    // 3. Pack two nibbles into one byte
+    let even_b = vuzp1q_u8(nibbles, nibbles); // p0, p2, p4, p6
+    let odd_b = vuzp2q_u8(nibbles, nibbles); // p1, p3, p5, p7
+    let packed = vorrq_u8(even_b, vshlq_n_u8(odd_b, 4));
+
+    // 4. Return the first lane (lower 32 bits)
+    vgetq_lane_u32(vreinterpretq_u32_u8(packed), 0)
+}
+
+/// Return `true` if every byte in `v` is a valid nucleotide (case‑insensitive).
+#[inline(always)]
+unsafe fn valid_block(v: uint8x16_t) -> bool {
+    let lower = vorrq_u8(v, vdupq_n_u8(0x20));
+    let is_a = vceqq_u8(lower, vdupq_n_u8(b'a'));
+    let is_c = vceqq_u8(lower, vdupq_n_u8(b'c'));
+    let is_g = vceqq_u8(lower, vdupq_n_u8(b'g'));
+    let is_t = vceqq_u8(lower, vdupq_n_u8(b't'));
+    let ok = vorrq_u8(is_a, vorrq_u8(is_c, vorrq_u8(is_g, is_t)));
+    vminvq_u8(ok) == 0xFF
+}
+
+/// Encode an arbitrary‑length ASCII slice into packed 2‑bit words (`u64`).
+///
+/// * 32 nt per word.
+/// * `output` must be large enough; otherwise `Err(())` is returned.
+/// * On any invalid byte the function zero‑fills `output` and returns `Err(())`.
+#[cfg(target_arch = "aarch64")]
+pub unsafe fn encode_nucleotides_simd(input: &[u8], output: &mut [u64]) -> Result<(), ()> {
+    let need = (input.len() + 31) / 32;
+    if output.len() < need {
+        return Err(());
+    }
+
+    output.fill(0);
+
+    let mut ip = input.as_ptr();
+    let mut left = input.len();
+    let mut out = output.as_mut_ptr();
+
+    // Vector loop: 32 nt → 1 u64
+    while left >= 32 {
+        let v0 = vld1q_u8(ip);
+        let v1 = vld1q_u8(ip.add(16));
+        if !valid_block(v0) || !valid_block(v1) {
+            return Err(());
+        }
+        *out = (encode_16_nucleotides(v0) as u64) | ((encode_16_nucleotides(v1) as u64) << 32);
+
+        ip = ip.add(32);
+        left -= 32;
+        out = out.add(1);
+    }
+
+    // Scalar tail (≤ 31 nt)
+    if left != 0 {
+        let mut tail = 0u64;
+        for i in 0..left {
+            tail |= match *ip.add(i) | 0x20 {
+                b'a' => 0u64,
+                b'c' => 1u64,
+                b'g' => 2u64,
+                b't' => 3u64,
+                _ => return Err(()),
+            } << (2 * i);
+        }
+        *out = tail;
+    }
+    Ok(())
+}
+
+/// Decode 16 packed 2‑bit codes (`u32`) to ASCII (`A`, `C`, `G`, `T`).
+#[inline(always)]
+pub unsafe fn decode_16_nucleotides(encoded: u32, dst: *mut u8) {
+    // 1. Broadcast the word to four lanes
+    let val = vdupq_n_u32(encoded);
+    let mask = vdupq_n_u32(3);
+
+    // 2. Extract 2‑bit fields (negative counts = right shift)
+    #[inline(always)]
+    const fn shv(a: i32, b: i32, c: i32, d: i32) -> int32x4_t {
+        unsafe { core::mem::transmute([a, b, c, d]) }
+    }
+    let c0 = vandq_u32(vshlq_u32(val, shv(0, -2, -4, -6)), mask);
+    let c1 = vandq_u32(vshlq_u32(val, shv(-8, -10, -12, -14)), mask);
+    let c2 = vandq_u32(vshlq_u32(val, shv(-16, -18, -20, -22)), mask);
+    let c3 = vandq_u32(vshlq_u32(val, shv(-24, -26, -28, -30)), mask);
+
+    // 3. Narrow u32 → u8 and assemble 16 indices
+    let idx: uint8x16_t = vcombine_u8(
+        vmovn_u16(vcombine_u16(vmovn_u32(c0), vmovn_u32(c1))),
+        vmovn_u16(vcombine_u16(vmovn_u32(c2), vmovn_u32(c3))),
+    );
+
+    // 4. LUT: 0→A, 1→C, 2→G, 3→T
+    let lut: uint8x16_t = core::mem::transmute([
+        b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T', b'A', b'C', b'G',
+        b'T',
+    ]);
+    let ascii = vqtbl1q_u8(lut, idx);
+
+    // 5. Store
+    vst1q_u8(dst, ascii);
+}
+
+/// Decode a packed 2‑bit stream (`u64` words) back to ASCII nucleotides.
+#[cfg(target_arch = "aarch64")]
+pub unsafe fn decode_nucleotides_simd(
+    input: &[u64],
+    len: usize,
+    output: &mut [u8],
+) -> Result<(), ()> {
+    if len > output.len() {
+        return Err(());
+    }
+
+    let chunk = 32;
+    let chunks = len / chunk;
+
+    for i in 0..chunks {
+        let w = input.get(i).copied().unwrap_or(0);
+        decode_16_nucleotides(w as u32, output.as_mut_ptr().add(i * chunk));
+        decode_16_nucleotides((w >> 32) as u32, output.as_mut_ptr().add(i * chunk + 16));
+    }
+
+    // Scalar tail
+    let lut = [b'A', b'C', b'G', b'T'];
+    for j in (chunks * chunk)..len {
+        let idx = ((input[j / 32] >> (2 * (j % 32))) & 3) as usize;
+        output[j] = lut[idx];
+    }
+    Ok(())
+}
+
+// Convenience wrappers ---------------------------------------------------
+
+pub fn encode(seq: &[u8], out: &mut Vec<u64>) -> Result<(), ()> {
+    out.resize((seq.len() + 31) / 32, 0);
+    unsafe { encode_nucleotides_simd(seq, out) }
+}
+
+pub fn decode(enc: &[u64], len: usize, out: &mut Vec<u8>) -> Result<(), ()> {
+    out.resize(len, 0);
+    unsafe { decode_nucleotides_simd(enc, len, out) }
+}
+
+// Tests ------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn neon_available() {
+        assert!(is_neon_supported());
+    }
+
+    #[test]
+    #[cfg(target_arch = "aarch64")]
+    fn roundtrip_16() {
+        let src = b"ACGTACGTACGTACGT";
+        let mut enc = [0u64; 1];
+        let mut dec = [0u8; 16];
+        unsafe {
+            encode_nucleotides_simd(src, &mut enc).unwrap();
+            decode_nucleotides_simd(&enc, src.len(), &mut dec).unwrap();
+        }
+        assert_eq!(src, &dec);
+    }
+
+    #[test]
+    #[cfg(target_arch = "aarch64")]
+    fn reject_invalid() {
+        let src = b"ACGTACGTNACGTACGT"; // contains 'N'
+        let mut enc = [0u64; 1];
+        assert!(unsafe { encode_nucleotides_simd(src, &mut enc) }.is_err());
+    }
+}

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -1,0 +1,25 @@
+//! SIMD implementations for faster nucleotide processing
+//!
+//! Contains vectorized implementations for nucleotide encoding and decoding
+//! using SIMD instructions on supported platforms.
+
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+
+/// Check if SIMD is supported and not disabled by environment
+pub fn is_simd_supported() -> bool {
+    // Check for environment override
+    if std::env::var("DISABLE_SIMD").is_ok() {
+        return false;
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        aarch64::is_neon_supported()
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        false
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -139,13 +139,13 @@ impl Encoder {
 
         // Fill the buffer with the 2-bit representation of the nucleotides
         self.clear();
-        if bitnuc::encode(primary, &mut self.sbuffer).is_err() {
+        if crate::nuc::encode(primary, &mut self.sbuffer).is_err() {
             self.clear();
             if self
                 .policy
                 .handle(primary, &mut self.s_ibuf, &mut self.rng)?
             {
-                bitnuc::encode(&self.s_ibuf, &mut self.sbuffer)?;
+                crate::nuc::encode(&self.s_ibuf, &mut self.sbuffer)?;
             } else {
                 return Ok(None);
             }
@@ -178,8 +178,8 @@ impl Encoder {
         }
 
         self.clear();
-        if bitnuc::encode(primary, &mut self.sbuffer).is_err()
-            || bitnuc::encode(extended, &mut self.xbuffer).is_err()
+        if crate::nuc::encode(primary, &mut self.sbuffer).is_err()
+            || crate::nuc::encode(extended, &mut self.xbuffer).is_err()
         {
             self.clear();
             if self
@@ -189,8 +189,8 @@ impl Encoder {
                     .policy
                     .handle(extended, &mut self.x_ibuf, &mut self.rng)?
             {
-                bitnuc::encode(&self.s_ibuf, &mut self.sbuffer)?;
-                bitnuc::encode(&self.x_ibuf, &mut self.xbuffer)?;
+                crate::nuc::encode(&self.s_ibuf, &mut self.sbuffer)?;
+                crate::nuc::encode(&self.x_ibuf, &mut self.xbuffer)?;
             } else {
                 return Ok(None);
             }


### PR DESCRIPTION
Hello this is a very cool project! 

This PR adds an optimized implementation for `aarch64` machines via `NEON` intrininsics

### Bench

The changes include a very simple benchmark that can be run like

```bash
cargo run --release --example bench_simd
```

```txt
Architecture: aarch64 (ARM64)
SIMD support detected: true

Encode Benchmark Results
----------------------------------------------------------------------------------------------------------
| Length     | Iterations | Original (ms)   | SIMD (ms)       | Orig (Mnuc/s) | SIMD (Mnuc/s) | Speedup  |
----------------------------------------------------------------------------------------------------------
| 32         | 1000       | 0               | 0               | 417.62        | 405.27        | 0.97x    |
| 64         | 1000       | 0               | 0               | 391.64        | 409.93        | 1.05x    |
| 100        | 1000       | 0               | 0               | 404.45        | 486.91        | 1.20x    |
| 1000       | 1000       | 2               | 1               | 492.97        | 537.60        | 1.09x    |
| 10000      | 1000       | 7               | 1               | 1290.68       | 9450.30       | 7.32x    |
| 100000     | 1000       | 56              | 10              | 1756.59       | 9832.60       | 5.60x    |
| 1000000    | 1000       | 574             | 95              | 1741.44       | 10440.67      | 6.00x    |
| 5000000    | 1000       | 2866            | 481             | 1744.01       | 10389.16      | 5.96x    |
----------------------------------------------------------------------------------------------------------

Decode Benchmark Results
----------------------------------------------------------------------------------------------------------
| Length     | Iterations | Original (ms)   | SIMD (ms)       | Orig (Mnuc/s) | SIMD (Mnuc/s) | Speedup  |
----------------------------------------------------------------------------------------------------------
| 32         | 1000       | 0               | 0               | 4000.00       | 3898.64       | 0.97x    |
| 64         | 1000       | 0               | 0               | 5505.38       | 5052.90       | 0.92x    |
| 100        | 1000       | 0               | 0               | 5491.79       | 5217.57       | 0.95x    |
| 1000       | 1000       | 0               | 0               | 6659.25       | 6618.88       | 0.99x    |
| 10000      | 1000       | 1               | 1               | 6693.82       | 6664.63       | 1.00x    |
| 100000     | 1000       | 14              | 4               | 6712.22       | 20469.61      | 3.05x    |
| 1000000    | 1000       | 194             | 48              | 5131.55       | 20795.86      | 4.05x    |
| 5000000    | 1000       | 970             | 237             | 5151.39       | 21073.47      | 4.09x    |
----------------------------------------------------------------------------------------------------------
```

notable these changes only show a speedup at long sequence lengths (>1000) as the overhead required outweigh any performance gains. In the changes we only apply the new function if the input `>1000` with a minor impact for the added conditional check.


### Combined with parallel processing

As noted the impact is seen at larger sequence lengths so if the `parallel_processing.rs` file is updated to use larger sequence lengths the performance gains are pronounced.

```rust
let r1_size = 1_500_000;
let r2_size = 3_000_000;
let num_seq = 1000;
```

then running the example

```bash
cargo run --release --example parallel_processing
#     Finished `release` profile [optimized] target(s) in 0.03s
#      Running `target/release/examples/parallel_processing`
# Finished writing 1000 records to path: ./data/test.bq
# Elapsed time (write_single): 5.790401542s
# Finished writing 1000 records to path: ./data/test_paired.bq
# Elapsed time (write_paired): 17.304640042s
# Elapsed time (single - mmap_parallel_processing (1)): 103.262875ms
# Elapsed time (single - mmap_parallel_processing (2)): 51.064292ms
# Elapsed time (single - mmap_parallel_processing (4)): 27.45525ms
# Elapsed time (single - mmap_parallel_processing (6)): 18.840167ms
# Elapsed time (single - mmap_parallel_processing (8)): 15.057875ms
# Elapsed time (single - mmap_parallel_processing (10)): 15.177208ms
# Elapsed time (single - mmap_parallel_processing (12)): 15.125666ms
# Elapsed time (single - mmap_parallel_processing (14)): 15.347084ms
# Elapsed time (single - mmap_parallel_processing (16)): 15.18525ms
# Elapsed time (paired - mmap_parallel_processing (1)): 293.514375ms
# Elapsed time (paired - mmap_parallel_processing (2)): 141.172ms
# Elapsed time (paired - mmap_parallel_processing (4)): 77.872583ms
# Elapsed time (paired - mmap_parallel_processing (6)): 57.239875ms
# Elapsed time (paired - mmap_parallel_processing (8)): 53.115916ms
# Elapsed time (paired - mmap_parallel_processing (10)): 50.590417ms
# Elapsed time (paired - mmap_parallel_processing (12)): 48.925666ms
# Elapsed time (paired - mmap_parallel_processing (14)): 50.635833ms
# Elapsed time (paired - mmap_parallel_processing (16)): 50.277625ms
```

and with the new changes disabled

```bash
DISABLE_SIMD=1 cargo run --release --example parallel_processing
#     Finished `release` profile [optimized] target(s) in 0.03s
#      Running `target/release/examples/parallel_processing_long_bp`
# Finished writing 1000 records to path: ./data/test.bq
# Elapsed time (write_single): 6.517152875s
# Finished writing 1000 records to path: ./data/test_paired.bq
# Elapsed time (write_paired): 19.553436125s
# Elapsed time (single - mmap_parallel_processing (1)): 320.603167ms
# Elapsed time (single - mmap_parallel_processing (2)): 167.1955ms
# Elapsed time (single - mmap_parallel_processing (4)): 83.050459ms
# Elapsed time (single - mmap_parallel_processing (6)): 57.442542ms
# Elapsed time (single - mmap_parallel_processing (8)): 44.447916ms
# Elapsed time (single - mmap_parallel_processing (10)): 38.634167ms
# Elapsed time (single - mmap_parallel_processing (12)): 35.195ms
# Elapsed time (single - mmap_parallel_processing (14)): 42.031541ms
# Elapsed time (single - mmap_parallel_processing (16)): 40.494667ms
# Elapsed time (paired - mmap_parallel_processing (1)): 994.009084ms
# Elapsed time (paired - mmap_parallel_processing (2)): 500.7545ms
# Elapsed time (paired - mmap_parallel_processing (4)): 255.31825ms
# Elapsed time (paired - mmap_parallel_processing (6)): 172.418084ms
# Elapsed time (paired - mmap_parallel_processing (8)): 133.924333ms
# Elapsed time (paired - mmap_parallel_processing (10)): 110.315458ms
# Elapsed time (paired - mmap_parallel_processing (12)): 106.56625ms
# Elapsed time (paired - mmap_parallel_processing (14)): 103.104708ms
# Elapsed time (paired - mmap_parallel_processing (16)): 108.734792ms
```

This shows a sizable speedup of +2-3x in both the single thread and multi-threaded cases on the longer sequences

Thanks again! Please let me know if I should make any changes 🙏