### PR TITLE
fix(cbq): correct silent N to A corruption on CBQ decode (#94)

### DIFF
--- a/src/cbq/core/block.rs
+++ b/src/cbq/core/block.rs
@@ -457,6 +457,9 @@ impl ColumnarBlock {
             // read the leading zeros and reconstruct an empty EliasFano (`num_ones() == 0`),
             // silently dropping every N on decode. See ArcInstitute/binseq#94.
             self.ef_bytes.clear();
+            // Pre-size (capacity only, not length): the decompressed EF is exactly
+            // `len_nef` bytes, so this avoids reallocations while `copy_decode` appends.
+            self.ef_bytes.reserve(self.len_nef);
             copy_decode(self.z_npos.as_slice(), &mut self.ef_bytes)?;
 
             let ef = EliasFano::deserialize_from(self.ef_bytes.as_slice())?;

--- a/src/cbq/core/block.rs
+++ b/src/cbq/core/block.rs
@@ -112,6 +112,7 @@ impl ColumnarBlock {
             self.num_records = 0;
             self.current_size = 0;
             self.num_npos = 0;
+            self.len_nef = 0;
         }
 
         // clear spans
@@ -450,7 +451,12 @@ impl ColumnarBlock {
 
         // decompress npos
         if !self.z_npos.is_empty() {
-            self.ef_bytes.resize(self.len_nef, 0);
+            // Clear (do NOT `resize(len_nef, 0)`): `copy_decode`'s destination is a
+            // `&mut Vec<u8>`, whose `io::Write` impl *appends*. Pre-filling with zeros would
+            // leave `ef_bytes == [0; len_nef] ++ [real EF bytes]`, so `deserialize_from` would
+            // read the leading zeros and reconstruct an empty EliasFano (`num_ones() == 0`),
+            // silently dropping every N on decode. See ArcInstitute/binseq#94.
+            self.ef_bytes.clear();
             copy_decode(self.z_npos.as_slice(), &mut self.ef_bytes)?;
 
             let ef = EliasFano::deserialize_from(self.ef_bytes.as_slice())?;

--- a/src/cbq/read.rs
+++ b/src/cbq/read.rs
@@ -634,4 +634,79 @@ mod tests {
         let final_count = *count.lock().unwrap();
         assert_eq!(final_count, num_records);
     }
+
+    // ==================== N-nucleotide round-trip (issue #94) ====================
+
+    /// Collects each record's `(global index, decoded sequence)` during parallel
+    /// processing so the result can be re-ordered and compared to the input.
+    #[derive(Clone)]
+    struct SeqCollector {
+        seqs: Arc<std::sync::Mutex<Vec<(u64, Vec<u8>)>>>,
+    }
+    impl ParallelProcessor for SeqCollector {
+        fn process_record<R: BinseqRecord>(&mut self, record: R) -> Result<()> {
+            let mut buf = Vec::new();
+            record.decode_s(&mut buf)?;
+            self.seqs.lock().unwrap().push((record.index(), buf));
+            Ok(())
+        }
+    }
+
+    /// The mmap / `process_parallel` decode path must restore every `N`.
+    /// Complements the serial-path tests in `write.rs` for ArcInstitute/binseq#94.
+    #[test]
+    fn test_n_roundtrip_parallel_mmap() -> Result<()> {
+        use crate::{BinseqWriterBuilder, SequencingRecordBuilder, write::Format};
+
+        // N-containing sequences; a small block size forces multiple blocks so
+        // several threads each decode N-bearing blocks.
+        let seqs: Vec<Vec<u8>> = (0..128u32)
+            .map(|i| {
+                if i % 7 == 0 {
+                    vec![b'N'; 8]
+                } else {
+                    let mut s = vec![b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T'];
+                    let pos = i as usize % s.len();
+                    s[pos] = b'N';
+                    s
+                }
+            })
+            .collect();
+
+        let path =
+            std::env::temp_dir().join(format!("binseq_n94_parallel_{}.cbq", std::process::id()));
+
+        // Write to a real file (MmapReader requires a path).
+        {
+            let mut writer = BinseqWriterBuilder::new(Format::Cbq)
+                .block_size(64)
+                .build(std::fs::File::create(&path)?)?;
+            for seq in &seqs {
+                writer.push(SequencingRecordBuilder::default().s_seq(seq).build()?)?;
+            }
+            writer.finish()?;
+        }
+
+        // Decode back in parallel via mmap.
+        let collected = Arc::new(std::sync::Mutex::new(Vec::<(u64, Vec<u8>)>::new()));
+        {
+            let reader = MmapReader::new(&path)?;
+            assert!(reader.num_blocks() > 1, "expected multiple blocks");
+            let processor = SeqCollector {
+                seqs: collected.clone(),
+            };
+            reader.process_parallel(processor, 4)?;
+        }
+
+        let _ = std::fs::remove_file(&path);
+
+        let mut got = Arc::try_unwrap(collected).unwrap().into_inner().unwrap();
+        got.sort_by_key(|(idx, _)| *idx);
+        let got_seqs: Vec<Vec<u8>> = got.into_iter().map(|(_, s)| s).collect();
+        assert_eq!(
+            got_seqs, seqs,
+            "parallel mmap decode must round-trip N positions"
+        );
+        Ok(())
+    }
 }

--- a/src/cbq/write.rs
+++ b/src/cbq/write.rs
@@ -451,4 +451,145 @@ mod tests {
 
         Ok(())
     }
+
+    // ==================== N-nucleotide round-trip (issue #94) ====================
+    //
+    // CBQ stores `N` as a 2-bit placeholder `A` plus an Elias-Fano index of the
+    // N-positions that is used to backfill `N` on decode. These tests guard the
+    // serial `Reader`/`decompress_columns` path, which previously dropped every N
+    // (decoding it back as `A`). See ArcInstitute/binseq#94.
+
+    /// Build a `FileHeader` with quality scores and headers enabled.
+    fn header_with_quality_headers(block_size: usize) -> FileHeader {
+        FileHeaderBuilder::default()
+            .is_paired(false)
+            .with_headers(true)
+            .with_qualities(true)
+            .with_flags(false)
+            .with_block_size(block_size)
+            .build()
+    }
+
+    /// Read back every record's `(sequence, quality, header)` from a finished CBQ buffer.
+    fn read_all_records(bytes: Vec<u8>) -> Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+        let mut reader = Reader::new(Cursor::new(bytes)).expect("failed to open reader");
+        let mut out = Vec::new();
+        let mut cumulative = 0u64;
+        while let Some(block_header) = reader.read_block().expect("failed to read block") {
+            cumulative += block_header.num_records;
+            reader
+                .block
+                .decompress_columns()
+                .expect("failed to decompress block");
+            let range = BlockRange::new(0, cumulative);
+            for rec in reader.block.iter_records(range) {
+                out.push((
+                    rec.sseq().to_vec(),
+                    rec.squal().to_vec(),
+                    rec.sheader().to_vec(),
+                ));
+            }
+        }
+        out
+    }
+
+    /// Sequences with `N` at every notable position: leading, interior, trailing,
+    /// all-N, and a no-N control. Direct reproduction of ArcInstitute/binseq#94.
+    #[test]
+    fn test_n_roundtrip_serial_edge_positions() -> Result<()> {
+        let seqs: Vec<&[u8]> = vec![
+            b"NACGTACGT", // leading
+            b"ACGTNACGT", // interior
+            b"ACGTACGTN", // trailing
+            b"NNNNNNNN",  // all-N
+            b"ACGTACGT",  // no-N control
+        ];
+
+        // Large block size: all records land in a single block.
+        let mut writer = ColumnarBlockWriter::new(Vec::new(), header(1 << 20))?;
+        for &seq in &seqs {
+            writer.push(record(seq))?;
+        }
+        writer.finish()?;
+
+        let read_back = read_all_sequences(writer.inner);
+        let expected: Vec<Vec<u8>> = seqs.iter().map(|s| s.to_vec()).collect();
+        assert_eq!(read_back, expected, "N positions must round-trip verbatim");
+        Ok(())
+    }
+
+    /// Many N-containing sequences with a small block size, forcing multiple
+    /// blocks. Guards per-block Elias-Fano correctness and `ef_bytes`/`len_nef`
+    /// reuse across `clear()`.
+    #[test]
+    fn test_n_roundtrip_serial_multi_block() -> Result<()> {
+        let seqs: Vec<Vec<u8>> = (0..64u32)
+            .map(|i| {
+                if i % 5 == 0 {
+                    // occasionally all-N
+                    vec![b'N'; 8]
+                } else {
+                    // vary N placement so per-block position sets differ
+                    let mut s = vec![b'A', b'C', b'G', b'T', b'A', b'C', b'G', b'T'];
+                    let pos = i as usize % s.len();
+                    s[pos] = b'N';
+                    s
+                }
+            })
+            .collect();
+
+        let mut writer = ColumnarBlockWriter::new(Vec::new(), header(64))?;
+        for seq in &seqs {
+            writer.push(record(seq))?;
+        }
+        writer.finish()?;
+
+        // Sanity: the small block size must actually span more than one block.
+        assert!(
+            writer.headers.len() > 1,
+            "expected multiple blocks, got {}",
+            writer.headers.len()
+        );
+
+        let read_back = read_all_sequences(writer.inner);
+        assert_eq!(
+            read_back, seqs,
+            "N round-trip must hold across multiple blocks"
+        );
+        Ok(())
+    }
+
+    /// Mirrors the exact reproduction in ArcInstitute/binseq#94: quality + headers
+    /// enabled, with N at leading / all / interior positions.
+    #[test]
+    fn test_n_roundtrip_with_quality_and_headers() -> Result<()> {
+        let records: [(&[u8], &[u8], &[u8]); 3] = [
+            (b"r1", b"NACGTACGT", b"IIIIIIIII"),
+            (b"r2", b"NNNNNNNN", b"IIIIIIII"),
+            (b"r3", b"ACGTNACGT", b"IIIIIIIII"),
+        ];
+
+        let mut writer =
+            ColumnarBlockWriter::new(Vec::new(), header_with_quality_headers(1 << 20))?;
+        for (h, s, q) in records {
+            let rec = SequencingRecordBuilder::default()
+                .s_header(h)
+                .s_seq(s)
+                .s_qual(q)
+                .build()?;
+            writer.push(rec)?;
+        }
+        writer.finish()?;
+
+        let read_back = read_all_records(writer.inner);
+        let expected: Vec<(Vec<u8>, Vec<u8>, Vec<u8>)> = records
+            .iter()
+            .map(|(h, s, q)| (s.to_vec(), q.to_vec(), h.to_vec()))
+            .collect();
+        assert_eq!(
+            read_back, expected,
+            "seq/qual/header must round-trip with N present"
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixes #94.

## Problem

A `.cbq` written with `N` bases does not round-trip: on decode every `N` comes back as `A`. In debug builds this panics inside sucds (`elias_fano/iter.rs:23`, `debug_assert_ne!(num_ones, 0)`); in the shipped release config it is **silent**, returning a real `A` where the read had a no-call `N`. For methylation/variant consumers this is a silent correctness violation.

## Root cause

CBQ stores `N` as a 2-bit placeholder `A` plus a sucds `EliasFano` index of the N-positions, backfilled on decode. In the serial `Reader` path, `ColumnarBlock::decompress_columns()` did:

```rust
self.ef_bytes.resize(self.len_nef, 0);              // pre-fills len_nef ZERO bytes
copy_decode(self.z_npos.as_slice(), &mut self.ef_bytes)?;  // io::Write for Vec<u8> APPENDS
```

`copy_decode`'s destination is a `&mut Vec<u8>`, whose `io::Write` impl **appends**. So `ef_bytes` became `[0u8; len_nef] ++ [real EF bytes]`, and `EliasFano::deserialize_from` read the leading zeros, producing an empty index (`num_ones() == 0`). `backfill_npos()` then panicked in debug or silently no-oped in release, leaving the placeholder `A`s.

This is not a sucds bug: its serialize/deserialize are symmetric. The other columns are fine because numeric columns decode into `cast_slice_mut(&mut vec)` (an in-place `&mut [u8]`), and `headers`/`qual` append into an already-cleared buffer with no `resize`. Only `ef_bytes` did both `resize(_, 0)` and append.

The mmap / `process_parallel` path (`decompress_from_bytes`, using `dctx.decompress`) writes at offset 0 via zstd-safe's `WriteBuf`, so it was already correct.

## Fix

Clear `ef_bytes` before `copy_decode` so it holds exactly the decompressed bytes, mirroring the `headers`/`qual` columns. Also reset `len_nef` in `ColumnarBlock::clear()` for consistent block reuse.

No on-disk format change: `z_npos` and `len_nef` are written correctly and already read back correctly by the mmap path, so `FILE_VERSION` is unchanged and existing files (N-free or not) are unaffected.

## Tests

Existing CBQ tests were ACGT-only, which is why this shipped. Added N-nucleotide round-trip coverage (leading / interior / trailing / all-N, single and multi-block, with and without quality+headers) over both the serial `Reader` path and the parallel `MmapReader`/`process_parallel` path. Verified these new tests fail (serial) on the pre-fix code and pass after; full suite green in debug and release; the exact issue repro prints `NACGTACGT`, `NNNNNNNN`, `ACGTNACGT` unchanged in both profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)