### PR TITLE
fix(cbq): read_index / MmapReader crash on zero-record CBQ files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] - 2026-08-10
+
+### Fixed
+
+- Support empty CBQ files in the `cbq` reader which previously failed due to index alignment error
+
 ## [0.9.4] - 2026-07-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ anyhow = "1.0.103"
 parking_lot = "0.12.5"
 clap = { version = "4.6.2", features = ["derive"] }
 paraseq = "0.4.14"
+tempfile = "3.27.0"
 
 [features]
 default = ["paraseq", "anyhow"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binseq"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 description = "A high efficiency binary format for sequencing data"
 license = "MIT"

--- a/src/cbq/core/index.rs
+++ b/src/cbq/core/index.rs
@@ -109,6 +109,13 @@ impl Index {
 
     /// Builds the index from a byte slice
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        // A zero-record CBQ has an empty index whose decompressed buffer has
+        // a dangling pointer, which fails `try_cast_slice`'s alignment check.
+        if bytes.is_empty() {
+            return Ok(Self {
+                ranges: Vec::default(),
+            });
+        }
         let ranges = match bytemuck::try_cast_slice(bytes) {
             Ok(ranges) => ranges.to_vec(),
             Err(_) => return Err(CbqError::IndexCastingError.into()),

--- a/src/cbq/read.rs
+++ b/src/cbq/read.rs
@@ -380,6 +380,36 @@ mod tests {
         assert!(num_blocks > 0, "Should have at least one block");
     }
 
+    // ==================== Empty File Tests ====================
+
+    /// A CBQ file containing zero records (e.g. produced when an upstream
+    /// filter discards every read) has an empty index. Reading the index
+    /// back must not fail: `bytemuck::try_cast_slice` rejects the empty
+    /// decompressed buffer because its dangling pointer is not aligned for
+    /// `BlockRange`, so `Index::from_bytes` needs an explicit empty guard.
+    #[test]
+    fn test_read_index_empty_file() {
+        use std::io::Cursor;
+
+        use crate::cbq::{ColumnarBlockWriter, core::FileHeaderBuilder};
+
+        let header = FileHeaderBuilder::default()
+            .is_paired(false)
+            .with_headers(false)
+            .with_qualities(false)
+            .with_flags(false)
+            .with_block_size(64)
+            .build();
+        let mut writer = ColumnarBlockWriter::new(Vec::new(), header).unwrap();
+        writer.finish().unwrap();
+
+        let mut reader = Reader::new(Cursor::new(writer.inner_data().to_vec())).unwrap();
+        while reader.read_block().unwrap().is_some() {}
+        let index = reader.read_index().unwrap().expect("index should exist");
+        assert_eq!(index.num_records(), 0);
+        assert_eq!(index.num_blocks(), 0);
+    }
+
     // ==================== Default Quality Score Tests ====================
 
     #[test]

--- a/src/cbq/read.rs
+++ b/src/cbq/read.rs
@@ -332,6 +332,10 @@ impl ParallelReader for MmapReader {
 }
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
     use super::*;
     use crate::BinseqRecord;
 
@@ -382,17 +386,8 @@ mod tests {
 
     // ==================== Empty File Tests ====================
 
-    /// A CBQ file containing zero records (e.g. produced when an upstream
-    /// filter discards every read) has an empty index. Reading the index
-    /// back must not fail: `bytemuck::try_cast_slice` rejects the empty
-    /// decompressed buffer because its dangling pointer is not aligned for
-    /// `BlockRange`, so `Index::from_bytes` needs an explicit empty guard.
-    #[test]
-    fn test_read_index_empty_file() {
-        use std::io::Cursor;
-
+    fn make_empty_cbq() -> Vec<u8> {
         use crate::cbq::{ColumnarBlockWriter, core::FileHeaderBuilder};
-
         let header = FileHeaderBuilder::default()
             .is_paired(false)
             .with_headers(false)
@@ -402,10 +397,36 @@ mod tests {
             .build();
         let mut writer = ColumnarBlockWriter::new(Vec::new(), header).unwrap();
         writer.finish().unwrap();
+        writer.inner_data().to_vec()
+    }
 
-        let mut reader = Reader::new(Cursor::new(writer.inner_data().to_vec())).unwrap();
+    /// A CBQ file containing zero records (e.g. produced when an upstream
+    /// filter discards every read) has an empty index. Reading the index
+    /// back must not fail: `bytemuck::try_cast_slice` rejects the empty
+    /// decompressed buffer because its dangling pointer is not aligned for
+    /// `BlockRange`, so `Index::from_bytes` needs an explicit empty guard.
+    #[test]
+    fn test_read_index_empty_file() {
+        use std::io::Cursor;
+
+        let empty_cbq = make_empty_cbq();
+        let mut reader = Reader::new(Cursor::new(empty_cbq)).unwrap();
         while reader.read_block().unwrap().is_some() {}
         let index = reader.read_index().unwrap().expect("index should exist");
+        assert_eq!(index.num_records(), 0);
+        assert_eq!(index.num_blocks(), 0);
+    }
+
+    #[test]
+    fn test_read_index_empty_file_mmap() {
+        let empty_cbq = make_empty_cbq();
+
+        let ntf = NamedTempFile::new().unwrap();
+        let (mut tmpfile, tmppath) = ntf.into_parts();
+        tmpfile.write_all(&empty_cbq).unwrap();
+
+        let reader = MmapReader::new(tmppath).unwrap();
+        let index = reader.index();
         assert_eq!(index.num_records(), 0);
         assert_eq!(index.num_blocks(), 0);
     }


### PR DESCRIPTION
# fix(cbq): read_index / MmapReader crash on zero-record CBQ files

## Summary

`Index::from_bytes` fails on empty input, so a **valid** CBQ file containing
zero records (e.g. a run where an upstream filter discarded every read) cannot
have its index read: both the streaming `Reader::read_index` and
`MmapReader::new` return `CbqError::IndexCastingError`
("Unable to cast bytes to Index - likely an alignment error"). This makes
`bqtools decode` (and any other index-reading consumer) crash on such files.

## Root cause

A zero-record CBQ has an empty index: `u_bytes = 0` and a 9-byte zstd frame of
zero-length content. After decompression the buffer is an empty `Vec<u8>`,
whose pointer is dangling and aligned only to 1.
`bytemuck::try_cast_slice::<u8, BlockRange>` checks pointer alignment even for
empty slices, so it returns `TargetAlignmentGreaterAndInputNotAligned`.

The bytes on disk are canonical — they are exactly what `ColumnarBlockWriter`
produces for empty input — so this is purely a reader-side issue.

## Fix

Guard the empty case before casting (`src/cbq/core/index.rs`):

```rust
if bytes.is_empty() {
    return Ok(Self { ranges: Vec::default() });
}
```

## Test

Added `cbq::read::tests::test_read_index_empty_file`
(`src/cbq/read.rs`): writes a zero-record CBQ via `ColumnarBlockWriter`,
reads it back with the streaming `Reader`, and asserts the index loads with
0 records / 0 blocks.

- Fails on current code with `CbqError(IndexCastingError)` — passes with the fix.
- Full suite green: `cargo test` (327 tests + doctests), `cargo fmt --check`, `cargo clippy`.
